### PR TITLE
Slot check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle/
+.idea/
 build/
 out/
 run/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/META-INF/
 /*.iws
 /*.ipr
 /*.iml
+*.bat

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.5.0-GTNH"
+version = "1.5.1-GTNH"
 group= "wanion.avaritiaddons" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Avaritiaddons"
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.4b.1-GTNH"
+version = "1.4b.2-GTNH"
 group= "wanion.avaritiaddons" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Avaritiaddons"
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://files.minecraftforge.net/maven"
         }
         maven {
             name = "sonatype"
@@ -11,13 +11,13 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.1'
     }
 }
 
 apply plugin: 'forge'
 
-version = "1.4b"
+version = "1.4b.1-GTNH"
 group= "wanion.avaritiaddons" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Avaritiaddons"
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.4b.2-GTNH"
+version = "1.5.0-GTNH"
 group= "wanion.avaritiaddons" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Avaritiaddons"
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.5.1-GTNH"
+version = "1.5.2-GTNH"
 group= "wanion.avaritiaddons" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Avaritiaddons"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip

--- a/src/main/java/wanion/avaritiaddons/block/chest/TileEntityAvaritiaddonsChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/TileEntityAvaritiaddonsChest.java
@@ -143,6 +143,12 @@ public abstract class TileEntityAvaritiaddonsChest extends TileEntity implements
 		++ticksSinceSync;
 		float f;
 
+		for (int i = 0; i < 243; i ++) {
+			if (inventoryAvaritiaddonsChest.contents[i] != null && inventoryAvaritiaddonsChest.contents[i].stackSize <= 0) {
+				inventoryAvaritiaddonsChest.contents[i] = null;
+			}
+		}
+
 		if (!worldObj.isRemote && numPlayersUsing != 0 && (ticksSinceSync + xCoord + yCoord + zCoord) % 200 == 0) {
 			numPlayersUsing = 0;
 			f = 5.0F;

--- a/src/main/java/wanion/avaritiaddons/block/chest/compressed/ItemRendererCompressedChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/compressed/ItemRendererCompressedChest.java
@@ -12,6 +12,8 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 import wanion.avaritiaddons.block.chest.RendererAvaritiaddonsChest;
 
 @SideOnly(Side.CLIENT)
@@ -38,5 +40,6 @@ public final class ItemRendererCompressedChest implements IItemRenderer
 			RendererAvaritiaddonsChest.instance.renderTileEntityAt(tileEntityCompressedChest, -0.5F, -0.5F, -0.5F, 0);
 		else
 			RendererAvaritiaddonsChest.instance.renderTileEntityAt(tileEntityCompressedChest, 0, 0, 0, 0);
+		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 	}
 }

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/ContainerInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/ContainerInfinityChest.java
@@ -50,9 +50,11 @@ public final class ContainerInfinityChest extends ContainerAvaritiaddonsChest
 					itemStack.stackSize = 0;
 					changed = true;
 				} else if (slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
-					slotStack.stackSize += itemStack.stackSize;
-					itemStack.stackSize = 0;
-					changed = true;
+					if ((long) slotStack.stackSize + (long) itemStack.stackSize <= (long) Integer.MAX_VALUE) {
+						slotStack.stackSize += itemStack.stackSize;
+						itemStack.stackSize = 0;
+						changed = true;
+					}
 				}
 				++currentSlot;
 			} else {
@@ -107,8 +109,10 @@ public final class ContainerInfinityChest extends ContainerAvaritiaddonsChest
 					else
 						actualSlot.onSlotChanged();
 				} else if (slotStack != null && slotStack.getItem() == playerStack.getItem() && (!playerStack.getHasSubtypes() || playerStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(playerStack, slotStack)) {
-					slotStack.stackSize += playerStack.stackSize;
-					entityPlayer.inventory.setItemStack(null);
+					if ((long) slotStack.stackSize + (long) playerStack.stackSize <= (long) Integer.MAX_VALUE) {
+						slotStack.stackSize += playerStack.stackSize;
+						entityPlayer.inventory.setItemStack(null);
+					}
 				}
 			} else if (mouseButton == 1 && playerStack != null) {
 				if (slotStack == null) {

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/ItemRendererInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/ItemRendererInfinityChest.java
@@ -12,6 +12,8 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
 import wanion.avaritiaddons.block.chest.RendererAvaritiaddonsChest;
 
 @SideOnly(Side.CLIENT)
@@ -38,5 +40,6 @@ public final class ItemRendererInfinityChest implements IItemRenderer
 			RendererAvaritiaddonsChest.instance.renderTileEntityAt(tileEntityInfinityChest, -0.5F, -0.5F, -0.5F, 0);
 		else
 			RendererAvaritiaddonsChest.instance.renderTileEntityAt(tileEntityInfinityChest, 0, 0, 0, 0);
+		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 	}
 }

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
@@ -133,17 +133,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 	@Override
 	public boolean isItemValidForSlot(final int slot, final ItemStack itemStack)
 	{
-		return slot != 243 || checkSlot(itemStack, slot);
-	}
-
-	private boolean checkSlot(@Nonnull final ItemStack itemStack, int slot)
-	{
-		if (slot >= 243) return false;
-		final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[slot];
-		if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
-			return (long) slotStack.stackSize + (long) itemStack.stackSize <= (long) Integer.MAX_VALUE;
-		}
-		return false;
+		return slot != 243;
 	}
 
 	@Override

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
@@ -39,7 +39,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 			return;
 		if (slot < 243) {
 			final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[slot];
-			if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
+			if (isSameItem(slotStack, itemStack)) {
 				int tmp = itemStack.stackSize;
 				itemStack.stackSize = slotStack.stackSize;
 				slotStack.stackSize = tmp;
@@ -66,11 +66,16 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 		markDirty();
 	}
 
+	private boolean isSameItem(ItemStack slotStack, ItemStack itemStack) {
+		if (slotStack == null || itemStack == null) return false;
+		return slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack);
+	}
+
 	private int findSlotFor(@Nonnull final ItemStack itemStack)
 	{
 		for (int i = 0; i < 243; i++) {
 			final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[i];
-			if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
+			if (isSameItem(slotStack, itemStack)) {
 				if ((long) slotStack.stackSize + (long) itemStack.stackSize <= (long) Integer.MAX_VALUE)
 					return i;
 			}
@@ -133,13 +138,13 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 	@Override
 	public boolean isItemValidForSlot(final int slot, final ItemStack itemStack)
 	{
-		return slot != 243;
+		return slot != 243 || findSlotFor(itemStack) != -1;
 	}
 
 	@Override
 	public final int getSizeInventory()
 	{
-		return 243;
+		return 244;
 	}
 
 	@Override

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
@@ -58,8 +58,10 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 	{
 		for (int i = 0; i < 243; i++) {
 			final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[i];
-			if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack))
-				return i;
+			if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
+				if ((long) slotStack.stackSize + (long) itemStack.stackSize <= (long) Integer.MAX_VALUE)
+					return i;
+			}
 		}
 		return -1;
 	}

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
@@ -40,9 +40,9 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 		if (slot < 243) {
 			final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[slot];
 			if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
-				itemStack.stackSize = itemStack.stackSize ^ slotStack.stackSize;
-				slotStack.stackSize = itemStack.stackSize ^ slotStack.stackSize;
-				itemStack.stackSize = itemStack.stackSize ^ slotStack.stackSize;
+				int tmp = itemStack.stackSize;
+				itemStack.stackSize = slotStack.stackSize;
+				slotStack.stackSize = tmp;
 				markDirty();
 				return;
 			}
@@ -55,9 +55,9 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 			} else inventoryAvaritiaddonsChest.contents[slot] = itemStack;
 		} else if (perfectSlot != -1) {
 			final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[slot];
-			itemStack.stackSize = itemStack.stackSize ^ slotStack.stackSize;
-			slotStack.stackSize = itemStack.stackSize ^ slotStack.stackSize;
-			itemStack.stackSize = itemStack.stackSize ^ slotStack.stackSize;
+			int tmp = itemStack.stackSize;
+			itemStack.stackSize = slotStack.stackSize;
+			slotStack.stackSize = tmp;
 			if (slotStack.stackSize <= 0)
 				inventoryAvaritiaddonsChest.contents[slot] = null;
 		} else {
@@ -138,6 +138,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 
 	private boolean checkSlot(@Nonnull final ItemStack itemStack, int slot)
 	{
+		if (slot >= 243) return false;
 		final ItemStack slotStack = inventoryAvaritiaddonsChest.contents[slot];
 		if (slotStack != null && slotStack.getItem() == itemStack.getItem() && (!itemStack.getHasSubtypes() || itemStack.getItemDamage() == slotStack.getItemDamage()) && ItemStack.areItemStackTagsEqual(itemStack, slotStack)) {
 			return (long) slotStack.stackSize + (long) itemStack.stackSize <= (long) Integer.MAX_VALUE;

--- a/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
+++ b/src/main/java/wanion/avaritiaddons/block/chest/infinity/TileEntityInfinityChest.java
@@ -139,7 +139,7 @@ public final class TileEntityInfinityChest extends TileEntityAvaritiaddonsChest
 	@Override
 	public final int getSizeInventory()
 	{
-		return 244;
+		return 243;
 	}
 
 	@Override


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8831

@repo-alt the `getSizeInventory()` is set to 244 intentionally, inf chest needs a fake slot to hold the input item temporarily and then merge it with existing items. so maybe you need to add special handler for inf chest in OC